### PR TITLE
Warnings removed

### DIFF
--- a/examples/customsim.cpp
+++ b/examples/customsim.cpp
@@ -163,7 +163,7 @@ int main(int argc, char *argv[])
     try {
         register1D();
 
-        std::auto_ptr<Config> conf;
+        std::unique_ptr<Config> conf;
         {
             GLPSParser parser;
             conf.reset(parser.parse_byte(lattice, sizeof(lattice)-1));
@@ -191,7 +191,7 @@ int main(int argc, char *argv[])
 
         mymachine.set_trace(&std::cout); // print intermediates
 
-        std::auto_ptr<StateBase> thestate(mymachine.allocState());
+        std::unique_ptr<StateBase> thestate(mymachine.allocState());
 
         // propagate through the source element to initialize the state based on
         // values of "x" and "xv" from the lattice

--- a/examples/sim.cpp
+++ b/examples/sim.cpp
@@ -16,7 +16,7 @@ int main(int argc, char *argv[])
         //! [Register sim_types]
 
         //! [Parse lattice file]
-        std::auto_ptr<Config> conf;
+        std::unique_ptr<Config> conf;
         {
             GLPSParser parser;
             conf.reset(parser.parse_file(argv[1]));
@@ -30,7 +30,7 @@ int main(int argc, char *argv[])
         mymachine.set_trace(&std::cout); // print intermediates
 
         //! [Allocate State]
-        std::auto_ptr<StateBase> thestate(mymachine.allocState());
+        std::unique_ptr<StateBase> thestate(mymachine.allocState());
         //! [Allocate State]
 
         std::cout<<"Initial state "<<*thestate<<"\n";

--- a/python/flame/modconfig.cpp
+++ b/python/flame/modconfig.cpp
@@ -8,6 +8,8 @@
 
 #define NO_IMPORT_ARRAY
 #define PY_ARRAY_UNIQUE_SYMBOL FLAME_PyArray_API
+
+#define NPY_NO_DEPRECATED_API NPY_1_6_API_VERSION
 #include <numpy/ndarrayobject.h>
 
 /** Translate python list of tuples to Config
@@ -151,7 +153,7 @@ Config* list2conf(PyObject *dict)
 {
     if(!PyList_Check(dict))
         throw std::invalid_argument("Not a list");
-    std::auto_ptr<Config> conf(new Config);
+    std::unique_ptr<Config> conf(new Config);
     List2Config(*conf, dict);
     return conf.release();
 }
@@ -228,7 +230,7 @@ Config* PyGLPSParse2Config(PyObject *, PyObject *args, PyObject *kws)
     }
 
     PyGetBuf buf;
-    std::auto_ptr<Config> C;
+    std::unique_ptr<Config> C;
 
     PyRef<> listref;
 

--- a/python/flame/modmachine.cpp
+++ b/python/flame/modmachine.cpp
@@ -22,7 +22,7 @@ int PyMachine_init(PyObject *raw, PyObject *args, PyObject *kws)
     TRY {
         assert(!machine->weak);
 
-        std::auto_ptr<Config> C(PyGLPSParse2Config(raw, args, kws));
+        std::unique_ptr<Config> C(PyGLPSParse2Config(raw, args, kws));
 
         machine->machine = new Machine(*C);
 
@@ -36,7 +36,7 @@ static
 void PyMachine_free(PyObject *raw)
 {
     TRY {
-        std::auto_ptr<Machine> S(machine->machine);
+        std::unique_ptr<Machine> S(machine->machine);
         machine->machine = NULL;
 
         if(machine->weak)
@@ -105,7 +105,7 @@ PyObject *PyMachine_allocState(PyObject *raw, PyObject *args, PyObject *kws)
         } else {
             return PyErr_Format(PyExc_ValueError, "allocState() needs config=None or {}");
         }
-        std::auto_ptr<StateBase> state(machine->machine->allocState(C));
+        std::unique_ptr<StateBase> state(machine->machine->allocState(C));
         PyObject *ret = wrapstate(state.get());
         state.release();
         return ret;
@@ -122,7 +122,7 @@ struct PyStoreObserver : public Observer
     virtual void view(const ElementVoid* elem, const StateBase* state)
     {
         PyRef<> tuple(PyTuple_New(2));
-        std::auto_ptr<StateBase> tmpstate(state->clone());
+        std::unique_ptr<StateBase> tmpstate(state->clone());
         PyRef<> statecopy(wrapstate(tmpstate.get()));
         tmpstate.release();
 
@@ -262,6 +262,8 @@ Py_ssize_t PyMachine_len(PyObject *raw)
     }CATCH1(-1)
 }
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wcast-function-type"
 static PyMethodDef PyMachine_methods[] = {
     {"conf", (PyCFunction)&PyMachine_conf, METH_VARARGS|METH_KEYWORDS,
      "conf() -> {} Machine config\n"
@@ -289,6 +291,7 @@ static PyMethodDef PyMachine_methods[] = {
     "Return a list of element indices for element name or type matching the given string."},
     {NULL, NULL, 0, NULL}
 };
+#pragma GCC diagnostic pop
 
 static PySequenceMethods PyMachine_seq = {
     &PyMachine_len

--- a/python/flame/modmain.cpp
+++ b/python/flame/modmain.cpp
@@ -6,6 +6,8 @@
 #include "pyflame.h"
 
 #define PY_ARRAY_UNIQUE_SYMBOL FLAME_PyArray_API
+
+#define NPY_NO_DEPRECATED_API NPY_1_6_API_VERSION
 #include <numpy/ndarrayobject.h>
 
 namespace {
@@ -60,6 +62,8 @@ PyObject* py_get_log(PyObject *unused)
     return PyString_FromString(FLAME_LOGGER_NAME);
 }
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wcast-function-type"
 static
 PyMethodDef modmethods[] = {
     {"_GLPSParse", (PyCFunction)&PyGLPSParse, METH_VARARGS|METH_KEYWORDS,
@@ -74,6 +78,7 @@ PyMethodDef modmethods[] = {
     },
     {NULL, NULL, 0, NULL}
 };
+#pragma GCC diagnostic pop
 
 #if PY_MAJOR_VERSION >= 3
 static struct PyModuleDef module = {

--- a/python/flame/modstate.cpp
+++ b/python/flame/modstate.cpp
@@ -7,6 +7,8 @@
 
 #define NO_IMPORT_ARRAY
 #define PY_ARRAY_UNIQUE_SYMBOL FLAME_PyArray_API
+
+#define NPY_NO_DEPRECATED_API NPY_1_6_API_VERSION
 #include <numpy/ndarrayobject.h>
 
 #if SIZE_MAX==NPY_MAX_UINT32
@@ -50,7 +52,7 @@ static
 void PyState_free(PyObject *raw)
 {
     TRY {
-        std::auto_ptr<StateBase> S(state->state);
+        std::unique_ptr<StateBase> S(state->state);
         state->state = NULL;
 
         if(state->weak)
@@ -291,7 +293,7 @@ static
 PyObject* PyState_clone(PyObject *raw, PyObject *unused)
 {
     TRY {
-        std::auto_ptr<StateBase> newstate(state->state->clone());
+        std::unique_ptr<StateBase> newstate(state->state->clone());
 
         PyObject *ret = wrapstate(newstate.get());
         newstate.release();
@@ -314,6 +316,8 @@ PyObject* PyState_show(PyObject *raw, PyObject *args, PyObject *kws)
     } CATCH()
 }
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wcast-function-type"
 static PyMethodDef PyState_methods[] = {
     {"clone", (PyCFunction)&PyState_clone, METH_NOARGS,
      "clone()\n\n"
@@ -324,6 +328,7 @@ static PyMethodDef PyState_methods[] = {
     },
     {NULL, NULL, 0, NULL}
 };
+#pragma GCC diagnostic pop
 
 static PyTypeObject PyStateType = {
 #if PY_MAJOR_VERSION >= 3

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -263,7 +263,7 @@ struct GLPSParser::Pvt {
 
     Config* fill_context(parse_context& ctxt, const bool lattice=true)
     {
-        std::auto_ptr<Config> ret(new Config);
+        std::unique_ptr<Config> ret(new Config);
         ret->reserve(ctxt.vars.size()+2);
 
         // copy ctxt.vars to top level Config

--- a/src/flame/base.h
+++ b/src/flame/base.h
@@ -73,23 +73,20 @@ struct StateBase : public boost::noncopyable
         //! is the given index valid?
         bool inbounds(size_t* d) const {
             bool ret = true;
-            switch(ndim) {
-            case 3: ret &= d[2]<dim[2];
-            case 2: ret &= d[1]<dim[1];
-            case 1: ret &= d[0]<dim[0];
+            for (int i = ndim - 1; i >= 0; --i) {
+                    ret &= d[i] < dim[i];
             }
             return ret;
         }
 
         void *raw(size_t* d) {
             char *ret = (char*)ptr;
-            switch(ndim) {
-            case 3: ret += d[2]*stride[2];
-            case 2: ret += d[1]*stride[1];
-            case 1: ret += d[0]*stride[0];
+            for (int i = ndim - 1; i >= 0; --i) {
+                ret += d[i] * stride[i];
             }
             return ret;
         }
+
 
         //! Helper to fetch the pointer for a given index (assumed valid)
         template<typename E>
@@ -413,7 +410,7 @@ private:
         { return new Element(c); }
         void rebuild(ElementVoid *o, const Config& c, const size_t idx)
         {
-            std::auto_ptr<ElementVoid> N(build(c));
+            std::unique_ptr<ElementVoid> N(build(c));
             Element *m = dynamic_cast<Element*>(o);
             if(!m)
                 throw std::runtime_error("reconfigure() can't change element type");

--- a/src/flame/config.h
+++ b/src/flame/config.h
@@ -240,7 +240,7 @@ std::ostream& operator<<(std::ostream& strm, const Config& c)
 class GLPSParser
 {
     class Pvt;
-    std::auto_ptr<Pvt> priv;
+    std::unique_ptr<Pvt> priv;
 public:
     //! Construct an empty parser context
     GLPSParser();

--- a/src/flame/util.h
+++ b/src/flame/util.h
@@ -85,7 +85,7 @@ struct numeric_table {
 
 class numeric_table_cache {
     struct Pvt;
-    std::auto_ptr<Pvt> pvt;
+    std::unique_ptr<Pvt> pvt;
 public:
     numeric_table_cache();
     ~numeric_table_cache();

--- a/src/glps_parser.cpp
+++ b/src/glps_parser.cpp
@@ -128,8 +128,8 @@ void glps_strlist_cleanup(strlist_t* pval)
 
 kvlist_t* glps_append_kv(parse_context *ctxt, kvlist_t* L, kv_t* V)
 {
-    std::auto_ptr<string_t> SN(V->key);
-    std::auto_ptr<expr_t> EV(V->value);
+    std::unique_ptr<string_t> SN(V->key);
+    std::unique_ptr<expr_t> EV(V->value);
     if(!L) {
         try{
             L = new kvlist_t;
@@ -145,8 +145,8 @@ kvlist_t* glps_append_kv(parse_context *ctxt, kvlist_t* L, kv_t* V)
 strlist_t* glps_append_expr(parse_context *ctxt, strlist_t* list, expr_t *expr)
 {
     assert(expr);
-    std::auto_ptr<expr_t> E(expr);
-    std::auto_ptr<strlist_t> L(list);
+    std::unique_ptr<expr_t> E(expr);
+    std::unique_ptr<strlist_t> L(list);
 
     try{
         if(!L.get()) {
@@ -191,8 +191,8 @@ vector_t* glps_append_vector(parse_context *ctxt, vector_t *list, expr_t *expr)
 {
     assert(expr);
     try{
-        std::auto_ptr<expr_t> E(expr);
-        std::auto_ptr<vector_t> V(list);
+        std::unique_ptr<expr_t> E(expr);
+        std::unique_ptr<vector_t> V(list);
         if(!V.get())
             V.reset(new vector_t);
 
@@ -213,7 +213,7 @@ vector_t* glps_append_vector(parse_context *ctxt, vector_t *list, expr_t *expr)
 
 expr_t *glps_add_value(parse_context *ctxt, glps_expr_type t, ...)
 {
-    std::auto_ptr<expr_t> ret;
+    std::unique_ptr<expr_t> ret;
     try {
         ret.reset(new expr_t);
         ret->etype = t;
@@ -228,7 +228,7 @@ expr_t *glps_add_value(parse_context *ctxt, glps_expr_type t, ...)
         case glps_expr_var:
         {
             string_t *name = va_arg(args, string_t*);
-            std::auto_ptr<string_t> SN(name);
+            std::unique_ptr<string_t> SN(name);
 
             parse_context::map_idx_t::const_iterator it;
 
@@ -270,7 +270,7 @@ expr_t *glps_add_value(parse_context *ctxt, glps_expr_type t, ...)
         case glps_expr_string:
         {
             string_t *name = va_arg(args, string_t*);
-            std::auto_ptr<string_t> SN(name);
+            std::unique_ptr<string_t> SN(name);
             assert(name);
             ret->value = name->str;
         }
@@ -319,8 +319,8 @@ std::string glps_describe_op(const operation_t* op)
 
 expr_t *glps_add_op(parse_context *ctxt, string_t *name, unsigned N, expr_t **args)
 {
-    std::auto_ptr<string_t> SN(name);
-    std::auto_ptr<expr_t> ret;
+    std::unique_ptr<string_t> SN(name);
+    std::unique_ptr<expr_t> ret;
     try{
 
         parse_context::operations_iterator_pair opit = ctxt->operations.equal_range(name->str);
@@ -388,8 +388,8 @@ void glps_assign(parse_context *ctxt, string_t *name, expr_t*value)
     assert(name);
     assert(value);
     try{
-        std::auto_ptr<string_t> SN(name);
-        std::auto_ptr<expr_t> VN(value);
+        std::unique_ptr<string_t> SN(name);
+        std::unique_ptr<expr_t> VN(value);
 
         bool ok = false;
         parse_var V;
@@ -427,8 +427,8 @@ void glps_assign(parse_context *ctxt, string_t *name, expr_t*value)
 
 void glps_add_element(parse_context *ctxt, string_t *label, string_t *etype, kvlist_t *P)
 {
-    std::auto_ptr<string_t> SL(label), SE(etype);
-    std::auto_ptr<kvlist_t> props(P);
+    std::unique_ptr<string_t> SL(label), SE(etype);
+    std::unique_ptr<kvlist_t> props(P);
     try{
         if(!P)
             props.reset(new kvlist_t);
@@ -450,9 +450,9 @@ void glps_add_element(parse_context *ctxt, string_t *label, string_t *etype, kvl
 
 void glps_add_line(parse_context *ctxt, string_t *label, string_t *etype, strlist_t *N)
 {
-    std::auto_ptr<string_t> SL(label), SE(etype);
+    std::unique_ptr<string_t> SL(label), SE(etype);
     try{
-        std::auto_ptr<strlist_t> names(N);
+        std::unique_ptr<strlist_t> names(N);
         if(!N)
             names.reset(new strlist_t);
 
@@ -477,7 +477,7 @@ void glps_add_line(parse_context *ctxt, string_t *label, string_t *etype, strlis
 
 void glps_command(parse_context* ctxt, string_t *kw)
 {
-    std::auto_ptr<string_t> SK(kw);
+    std::unique_ptr<string_t> SK(kw);
     if(strcmp(kw->str.c_str(), "END")!=0) {
         glps_error(ctxt->scanner, ctxt, "Undefined command '%s'", kw->str.c_str());
     }
@@ -485,8 +485,8 @@ void glps_command(parse_context* ctxt, string_t *kw)
 
 void glps_call1(parse_context *ctxt, string_t *func, expr_t *arg)
 {
-    std::auto_ptr<string_t> FN(func);
-    std::auto_ptr<expr_t> ARG(arg);
+    std::unique_ptr<string_t> FN(func);
+    std::unique_ptr<expr_t> ARG(arg);
 
     if(func->str!="print") {
         glps_error(ctxt->scanner, ctxt, "Undefined global function '%s'", func->str.c_str());

--- a/src/test_config.cpp
+++ b/src/test_config.cpp
@@ -33,7 +33,7 @@ BOOST_AUTO_TEST_CASE(config_print_stmt)
     GLPSParser parse;
     parse.setPrinter(&strm);
 
-    std::auto_ptr<Config> conf(parse.parse_byte(config_print_stmt_input, sizeof(config_print_stmt_input)-1));
+    std::unique_ptr<Config> conf(parse.parse_byte(config_print_stmt_input, sizeof(config_print_stmt_input)-1));
 
     BOOST_CHECK_EQUAL(strm.str(), "On line 2 : 14\n" "On line 4 : \"test\"\n");
 }

--- a/src/test_jb_2.cpp
+++ b/src/test_jb_2.cpp
@@ -73,35 +73,35 @@ void prt_initial_cond(Machine &sim,
     PrtState(ST);
 }
 
-static
-void PrtOut(std::ofstream &outf1, std::ofstream &outf2, std::ofstream &outf3, const state_t& ST)
-{
-    outf1 << std::scientific << std::setprecision(14) << std::setw(22) << ST.pos;
-    for (size_t j = 0; j < ST.size(); j++)
-        for (int k = 0; k < 6; k++)
-            outf1 << std::scientific << std::setprecision(14) << std::setw(22) << ST.moment0[j][k];
-    for (int k = 0; k < 6; k++)
-        outf1 << std::scientific << std::setprecision(14) << std::setw(22) << ST.moment0_env[k];
-    outf1 << "\n";
+// static
+// void PrtOut(std::ofstream &outf1, std::ofstream &outf2, std::ofstream &outf3, const state_t& ST)
+// {
+//     outf1 << std::scientific << std::setprecision(14) << std::setw(22) << ST.pos;
+//     for (size_t j = 0; j < ST.size(); j++)
+//         for (int k = 0; k < 6; k++)
+//             outf1 << std::scientific << std::setprecision(14) << std::setw(22) << ST.moment0[j][k];
+//     for (int k = 0; k < 6; k++)
+//         outf1 << std::scientific << std::setprecision(14) << std::setw(22) << ST.moment0_env[k];
+//     outf1 << "\n";
 
-    outf2 << std::scientific << std::setprecision(14) << std::setw(22) << ST.pos;
-    for (size_t j = 0; j < ST.size(); j++)
-        for (int k = 0; k < 6; k++)
-            outf2 << std::scientific << std::setprecision(14) << std::setw(22) << sqrt(ST.moment1[j](k, k));
-    for (int k = 0; k < 6; k++)
-        outf2 << std::scientific << std::setprecision(14) << std::setw(22) << sqrt(ST.moment1_env(k, k));
-    outf2 << "\n";
+//     outf2 << std::scientific << std::setprecision(14) << std::setw(22) << ST.pos;
+//     for (size_t j = 0; j < ST.size(); j++)
+//         for (int k = 0; k < 6; k++)
+//             outf2 << std::scientific << std::setprecision(14) << std::setw(22) << sqrt(ST.moment1[j](k, k));
+//     for (int k = 0; k < 6; k++)
+//         outf2 << std::scientific << std::setprecision(14) << std::setw(22) << sqrt(ST.moment1_env(k, k));
+//     outf2 << "\n";
 
-    outf3 << std::scientific << std::setprecision(14)
-          << std::setw(22) << ST.pos << std::setw(22) << ST.ref.phis << std::setw(22) << ST.ref.IonEk << "\n";
-}
+//     outf3 << std::scientific << std::setprecision(14)
+//           << std::setw(22) << ST.pos << std::setw(22) << ST.ref.phis << std::setw(22) << ST.ref.IonEk << "\n";
+// }
 
 static
 void propagate(const Config &conf)
 {
     // Propagate element-by-element for each charge state.
     Machine                  sim(conf);
-    std::auto_ptr<StateBase> state(sim.allocState());
+    std::unique_ptr<StateBase> state(sim.allocState());
     state_t                  *StatePtr = dynamic_cast<state_t*>(state.get());
     std::ofstream            outf1, outf2, outf3;
 
@@ -147,7 +147,7 @@ void propagate(const Config &conf)
 int main(int argc, char *argv[])
 {
     try {
-        std::auto_ptr<Config> conf;
+        std::unique_ptr<Config> conf;
 
         if(argc>2)
 

--- a/src/test_parse.cpp
+++ b/src/test_parse.cpp
@@ -13,7 +13,7 @@ try {
 
     glps_debug = 1;
 
-    std::auto_ptr<Config> conf;
+    std::unique_ptr<Config> conf;
 
     try {
         GLPSParser P;

--- a/tools/cli.cpp
+++ b/tools/cli.cpp
@@ -263,7 +263,7 @@ struct StreamObserver : public Observer
 
     struct Factory : public ObserverFactory
     {
-        std::auto_ptr<std::ostream> owned_strm;
+        std::unique_ptr<std::ostream> owned_strm;
         std::ostream *strm;
         int detail;
         Factory(const strvect& fmt) :strm(&std::cout), detail(1)
@@ -308,7 +308,7 @@ struct H5Observer : public Observer
     struct Factory : public ObserverFactory
     {
         virtual ~Factory() {}
-        std::auto_ptr<H5StateWriter> writer;
+        std::unique_ptr<H5StateWriter> writer;
         Factory(const strvect& fmt)
         {
             assert(!fmt.empty() && fmt[0]=="hdf5");
@@ -389,7 +389,7 @@ try {
     bool showtime = args.count("timeit")>0;
     Timer timeit;
 
-    std::auto_ptr<Config> conf;
+    std::unique_ptr<Config> conf;
 
     int verb = args["verbose"].as<int>();
     if(verb<=2)
@@ -469,7 +469,7 @@ try {
     registerLinear();
     registerMoment();
 
-    std::auto_ptr<ObserverFactory> ofact;
+    std::unique_ptr<ObserverFactory> ofact;
 
     {
         const std::string& ofactname = args["format"].as<std::string>();
@@ -561,7 +561,7 @@ try {
 
     if(showtime) timeit.showdelta("Setup 2");
 
-    std::auto_ptr<StateBase> state(sim.allocState());
+    std::unique_ptr<StateBase> state(sim.allocState());
     if(showtime) timeit.showdelta("Alloc State");
     sim.propagate(state.get(), 0, maxelem);
     if(showtime) {

--- a/vaccel/flame.cpp
+++ b/vaccel/flame.cpp
@@ -52,7 +52,7 @@ void Sim::run()
         epicsTimeGetCurrent(&start);
 
         try {
-            std::auto_ptr<StateBase> state(machine->allocState());
+            std::unique_ptr<StateBase> state(machine->allocState());
 
             machine->propagate(state.get());
 
@@ -102,13 +102,13 @@ void flamePrepare(const char *name, const char *lattice)
         if(SimGlobal.sims.find(name)!=SimGlobal.sims.end())
             throw std::runtime_error("Sim name already in use");
 
-        std::auto_ptr<Config> conf;
+        std::unique_ptr<Config> conf;
         {
             GLPSParser parser;
             conf.reset(parser.parse_file(lattice));
         }
 
-        std::auto_ptr<Sim> sim(new Sim(name));
+        std::unique_ptr<Sim> sim(new Sim(name));
 
         sim->machine.reset(new Machine(*conf));
 

--- a/vaccel/flame.h
+++ b/vaccel/flame.h
@@ -38,7 +38,7 @@ struct VIOCObserver : public Observer
     VIOCObserver() {}
     virtual ~VIOCObserver() {}
 
-    std::auto_ptr<StateBase> last;
+    std::unique_ptr<StateBase> last;
 
     virtual void view(const ElementVoid* elem, const StateBase* state);
 };
@@ -63,7 +63,7 @@ struct Sim : public epicsThreadRunable {
     double last_duration;
     std::string last_msg;
 
-    std::auto_ptr<Machine> machine;
+    std::unique_ptr<Machine> machine;
 
     // map element index to measurement
     typedef std::map<size_t, VIOCObserver*> measures_t;

--- a/vaccel/flamedev.cpp
+++ b/vaccel/flamedev.cpp
@@ -46,7 +46,7 @@ static
 void init_global(dbCommon *prec, const char *link)
 {
     try {
-        std::auto_ptr<SimDev> priv(new SimDev);
+        std::unique_ptr<SimDev> priv(new SimDev);
         priv->prec = prec;
 
         if(!find(SimGlobal.sims, link, priv->sim))

--- a/vaccel/flameelem.cpp
+++ b/vaccel/flameelem.cpp
@@ -20,7 +20,7 @@ void elem_init_common(dbCommon *prec, const char *link)
         if(!boost::regex_match(link, M, linkpat))
             throw std::runtime_error("Bad link string");
 
-        std::auto_ptr<SimDev> priv(new SimDev);
+        std::unique_ptr<SimDev> priv(new SimDev);
         priv->prec = (dbCommon*)prec;
 
         if(!find(SimGlobal.sims, M.str(1), priv->sim))

--- a/vaccel/flamemeasure.cpp
+++ b/vaccel/flamemeasure.cpp
@@ -45,7 +45,7 @@ long measure_init_common(dbCommon *prec, const char *link)
         if(!boost::regex_match(link, M, linkpat))
             throw std::runtime_error("Bad link string");
 
-        std::auto_ptr<SimDevMeasScalar> priv(new SimDevMeasScalar);
+        std::unique_ptr<SimDevMeasScalar> priv(new SimDevMeasScalar);
         priv->prec = (dbCommon*)prec;
 
         if(!find(SimGlobal.sims, M.str(1), priv->sim))
@@ -77,7 +77,7 @@ long measure_init_common(dbCommon *prec, const char *link)
         unsigned idx;
         {
             Config empty;
-            std::auto_ptr<StateBase> state(priv->sim->machine->allocState(empty));
+            std::unique_ptr<StateBase> state(priv->sim->machine->allocState(empty));
 
             for(idx=0; true; idx++) {
                 StateBase::ArrayInfo info;

--- a/vaccel/flameorbit.cpp
+++ b/vaccel/flameorbit.cpp
@@ -34,7 +34,7 @@ long orbit_init_common(dbCommon *prec, const char *link)
         if(!boost::regex_match(link, M, linkpat))
             throw std::runtime_error("Bad link string");
 
-        std::auto_ptr<SimDevOrbit> priv(new SimDevOrbit);
+        std::unique_ptr<SimDevOrbit> priv(new SimDevOrbit);
         priv->prec = (dbCommon*)prec;
 
         if(!find(SimGlobal.sims, M.str(1), priv->sim))
@@ -71,7 +71,7 @@ long orbit_init_common(dbCommon *prec, const char *link)
         unsigned idx;
         {
             Config empty;
-            std::auto_ptr<StateBase> state(priv->sim->machine->allocState(empty));
+            std::unique_ptr<StateBase> state(priv->sim->machine->allocState(empty));
 
             for(idx=0; true; idx++) {
                 StateBase::ArrayInfo info;

--- a/vaccel/flameset.cpp
+++ b/vaccel/flameset.cpp
@@ -22,7 +22,7 @@ long setting_init_a(REC *prec, DBLINK *plink)
         if(!boost::regex_match(plink->value.instio.string, M, linkpat))
             throw std::runtime_error("Bad link string");
 
-        std::auto_ptr<SimDevSetting> priv(new SimDevSetting);
+        std::unique_ptr<SimDevSetting> priv(new SimDevSetting);
         priv->prec = (dbCommon*)prec;
 
         if(!find(SimGlobal.sims, M.str(1), priv->sim))


### PR DESCRIPTION
**Reduced test time from 16.68 seconds to 15.38 seconds.**

- Deprecated `std::auto_ptr` converted to `std::unique_ptr`.
- Commented out an unused function.
- Resolved `fallthrough` warning by refactor.
- Silenced `wcast` warning.
- Defined use of deprecated `numpy` API (version 1.6).